### PR TITLE
FIX: never collapse if not collapsible

### DIFF
--- a/javascripts/discourse/components/versatile-banner.hbs
+++ b/javascripts/discourse/components/versatile-banner.hbs
@@ -27,7 +27,10 @@
         </div>
         <div
           id="banner-content_wrap"
-          class={{if this.bannerCollapsed "--banner-collapsed"}}
+          class={{if
+            (and (theme-setting "collapsible") this.bannerCollapsed)
+            "--banner-collapsed"
+          }}
         >
           <div class="row">
             {{#each this.columnData as |data|}}


### PR DESCRIPTION
If the setting `collapsible` is disabled, the banner should never be collapsed. Prior to this change it would be collapsed based on `default collapsed state` regardless. 
