### PR TITLE
UX: hide column containers if empty

### DIFF
--- a/javascripts/discourse/components/versatile-banner-column.hbs
+++ b/javascripts/discourse/components/versatile-banner-column.hbs
@@ -1,14 +1,18 @@
-<div class="{{@columnClass}} single-box">
-  {{#if @icon}}
-    <div class="icon">
-      {{#if this.isHttpLink}}
-        <img class="responsive-img" src={{@icon}} alt="Icon" />
-      {{else}}
-        {{d-icon @icon}}
-      {{/if}}
-    </div>
-  {{/if}}
-  <div>
-    {{html-safe @columnContent}}
+{{#if (or @icon @columnContent)}}
+  <div class="{{@columnClass}} single-box">
+    {{#if @icon}}
+      <div class="icon">
+        {{#if this.isHttpLink}}
+          <img class="responsive-img" src={{@icon}} alt="Icon" />
+        {{else}}
+          {{d-icon @icon}}
+        {{/if}}
+      </div>
+    {{/if}}
+    {{#if @columnContent}}
+      <div>
+        {{html-safe @columnContent}}
+      </div>
+    {{/if}}
   </div>
-</div>
+{{/if}}


### PR DESCRIPTION
This banner often gets used with empty column content, this will hide the containing divs if they're empty (the empty divs would still occupy a little space otherwise)