### PR TITLE
FIX: remove margin from empty container

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -292,7 +292,9 @@
 }
 
 .above-main-container-outlet.banner-themes {
-  margin-bottom: 1.75em;
+  .banner-box {
+    margin-bottom: 1.5em;
+  }
 }
 
 // new collapse animation to replace JQuery


### PR DESCRIPTION
depending on the theme setting, this connector may be empty, so the margin should be applied to its content to avoid adding extra space to the page 