### PR TITLE
UX: reduce font size for expand and close link

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -71,7 +71,7 @@
       border: none;
       color: #646464;
       background: transparent;
-      font-size: 1.5157em;
+      font-size: 1em;
       cursor: pointer;
 
       svg {


### PR DESCRIPTION
Before:

<img width="1128" alt="Screenshot 2024-11-06 at 4 33 21 PM" src="https://github.com/user-attachments/assets/915950be-1f54-472b-b4b2-8310323c8116">

After:

<img width="1138" alt="Screenshot 2024-11-06 at 4 32 53 PM" src="https://github.com/user-attachments/assets/3984577f-43d9-4220-874a-2a41c931ff72">

