### PR TITLE
Add margin-bottom to banner-box for better spacing

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -54,6 +54,7 @@
   max-width: calc(100% - 16px);
   margin: 0 auto;
   margin-top: 20px;
+  margin-bottom: 20px;
   color: var(--banner-primary-text);
   position: relative;
   background-image: var(--banner-bg-img);


### PR DESCRIPTION
Added `margin-bottom: 20px;` to `.banner-box` to enhance visual spacing and improve overall layout clarity.
